### PR TITLE
Clarified setting resolution, updates to USB camera

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ position: 1
 ---
 # Getting Started
 
-Welcome to the docs for **Robocon 2020**!
+Welcome to the docs for **Robocon 2024**!
 
 We suggest you first get familiar with the [rules](/rules.md). Once you've done that, you'll need to [turn your robot on](/turning-everything-on.html).
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -144,7 +144,7 @@ An interface to the camera is provided incase you want to do additional computer
 
 ### Changing the resolution
 
-The default the camera takes pictures at a resolution of **640x480px**. You can change this by setting the `res` parameter.
+By default the camera takes pictures at a resolution of **640x480px**. You can change this by setting the `res` parameter.
 
 ```python
 import robot
@@ -167,6 +167,9 @@ You must use one of the following resolutions:
 :::tip
  Using a higher resolution will increase the amount of time it takes to process the image, but you may be able to see more. Using a smaller resolution will be faster, but markers further away may stop being visible.
 :::
+::: warning
+The resolution values may be different on a USB camera. Please see [Using USB cameras](docs/vision.html#using-usb-cameras) for more information.
+:::
 
 ### Get data straight from the camera
 
@@ -185,7 +188,13 @@ image.colour_type # The encoding method used to store the colour_frame defaults 
 image.time # A `datetime` object representing approximately the capture time.
 ```
 
-### Using USB camera's
+## Using USB cameras
+
+The built-in Pi Camera inside your brain should be great for your robot, however if you would like to use your own USB Camera (perhaps you want to put a camera somewhere else on your robot), you can! 
+
+USB cameras can have slightly different functionality than the built-in Pi Camera, so they'll need some fine tuning before you can use them. The basic steps outlined below should get you up and running.
+
+Please **turn your robot off** before plugging in your USB Camera of choice.
 
 To use a USB camera you will need to initialize the `Robot` with something which inherits from `robot.vision.Camera`. Then just call `R.see()` as you would normally.
 
@@ -198,31 +207,67 @@ R = robot.Robot(camera=RoboConUSBCamera)
 print(R.see())
 ```
 
-You will then need to calibrate your camera as the distance that it reports will not be accurate. You can do this by changing the value in the `R.camera.params` dictionary up or down.
+### Setting the resolution
 
-To get the current value print it:
+You may now wish to change the resolution of your camera, this can be done the same as before with `R.camera.res = (width,height)`.
 
-```python
-print(R.camera.params)
-R.camera.params[(640, 480)] = (123, 123)
+::: tip
+Some resolutions may not work with your USB camera, as different cameras support different resolutions. Check your camera's documentation. If you try and use a resolution that your camera doesn't support, you will get an error that will state the closest resolution to the value you attempted to use. Try changing your resolution to the value that the error message suggests!
+:::
+
+For example, to set a USB Camera's resolution to `800x600`:
+
+``` python
+import robot
+from robot.vision import RoboConUSBCamera
+
+R = robot.Robot(camera=RoboConUSBCamera)
+
+R.camera.res = (800, 600)
+print(R.see())
 ```
 
-We recommend that you tune this value by placing a marker exactly 2m away, printing `R.see()` (remember to take an average), and tuning the focal length up or down until you get a value that is close to 2m. If you are feeling fancy you could even write a function to automatically tune the value.
+### Calibrating the camera
 
-Calibration data for a Logitech C270 is available:
+You will then need to calibrate your USB camera as the distance that it reports will not be accurate. You can do this by changing the value in the `R.camera.focal_lengths` dictionary up or down. By default, the robot will use the focal lengths for a "Logitech C270" camera, it's unlikely this is your camera - so see the steps below on how to calibrate it.
 
-```python
-LOGITECH_C270_FOCAL_LENGTHS = {  # fx, fy tuples
-    (640, 480): (607.6669874845361, 607.6669874845361),
-    (1296, 736): (1243.0561163806915, 1243.0561163806915),
-    (1296, 976): (1232.4906991188611, 1232.4906991188611),
-    (1920, 1088): (3142.634753484673, 3142.634753484673),
-    (1920, 1440): (1816.5165227051677, 1816.5165227051677)
-}
+::: tip
+Remember that focal lengths vary for different resolutions. You will need to run the calibration code below to find the focal length for each resolution you intend to use with your USB camera.
+:::
+
+- Place a marker exactly 1m away from the camera (measure this distance). Make sure there are no other markers in sight of the camera.
+- Copy and paste the following code into your editor. Please set the `resolution` value to a resolution you wish to use.
+
+``` python
+import robot
+from robot.vision import RoboConUSBCamera
+R = robot.Robot(camera=RoboConUSBCamera)
+
+resolution = (640, 480)
+
+R.camera.focal_lengths[resolution] = (120, 120) # set the focal lengths to a known bad value
+R.camera.res = resolution # set resolution
+
+marker = R.see()[0] # get first marker
+d = marker.dist
+focal_length = 120 / d # focal length = focal length / distance
+print("Focal length is around:",focal_length)
+print("Use this in your code to set the correct focal length: R.camera.focal_lengths[resolution] = ("+str(focal_length)+", "+str(focal_length)+")")
 ```
 
-This data can be imported:
+It's worth noting that this is only an average value. 
 
-```python
-from robot.vision import LOGITECH_C270_FOCAL_LENGTHS
+The code above will output a focal length value which you should use **before** setting `R.camera.res` or `R.see()`. You can also copy the line of code it produces and paste that into your code to set the focal lengths.
+
+For example, if your focal length was `123` at the resolution of `800x600`, you should use the following lines of code, in the **same order**:
+
+``` python
+import robot
+from robot.vision import RoboConUSBCamera
+R = robot.Robot(camera=RoboConUSBCamera)
+
+R.camera.focal_lengths[resolution] = (123, 123)
+R.camera.res = resolution
+
+marker = R.see()[0]
 ```

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -168,7 +168,7 @@ You must use one of the following resolutions:
  Using a higher resolution will increase the amount of time it takes to process the image, but you may be able to see more. Using a smaller resolution will be faster, but markers further away may stop being visible.
 :::
 ::: warning
-The resolution values may be different on a USB camera. Please see [Using USB cameras](docs/vision.html#using-usb-cameras) for more information.
+The resolution values may be different on a USB camera. Please see _Using USB Cameras_ (below) for more information.
 :::
 
 ### Get data straight from the camera


### PR DESCRIPTION
This brings the docs in line with the changes to `vision.py`. Key changes:

- Clarified that resolutions are different on USB Cameras
- Added a dedicated "USB Cameras" section
- Added instructions and info about plugging in, setting up, resolutions, focal lengths and calibration
- Embedded code to calibrate focal lengths
- Fixed the date in the `README` to be 2024 as it was bugging me.

Note that I won't merge this until the patch has been released, due to syntax changes on the new patch.